### PR TITLE
Track daily NVIDIA stock price changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,211 @@
+# NVIDIA 일일 주가 추적기 (NVIDIA Daily Stock Tracker)
+
+NVIDIA(NVDA)의 일일 주가 변동과 관련 뉴스를 자동으로 추적하여 Excel 파일에 기록하는 도구입니다.
+
+## 주요 기능
+
+- **일일 주가 데이터 수집**: 시가, 종가, 최고가, 최저가, 거래량
+- **변동률 계산**: 전일 대비 변동 금액 및 변동률 자동 계산
+- **뉴스 수집**: 해당 날짜의 NVIDIA 관련 뉴스 자동 수집
+- **Excel 자동 저장**: 데이터를 Excel 파일에 자동으로 누적 저장
+- **중복 방지**: 같은 날짜의 데이터는 업데이트됨
+
+## 설치 방법
+
+### 1. 필수 패키지 설치
+
+```bash
+pip install -r requirements.txt
+```
+
+필요한 패키지:
+- pandas: 데이터 처리
+- openpyxl: Excel 파일 작성
+- requests: 웹 API 호출
+
+### 2. 프로젝트 구조
+
+```
+test-repo/
+├── finance_util.py           # 핵심 유틸리티 함수들
+├── nvda_daily_tracker.py     # 메인 실행 스크립트
+├── requirements.txt          # 의존성 패키지 목록
+├── nvda_daily_tracker.xlsx   # 생성되는 추적 데이터 (자동 생성)
+└── README.md                 # 이 파일
+```
+
+## 사용 방법
+
+### 기본 사용 (오늘 날짜)
+
+```bash
+python nvda_daily_tracker.py
+```
+
+### 특정 날짜 지정
+
+```bash
+python nvda_daily_tracker.py 2026-01-15
+```
+
+### 출력 디렉토리 지정
+
+```bash
+python nvda_daily_tracker.py 2026-01-15 /path/to/output
+```
+
+## Excel 파일 구조
+
+생성되는 `nvda_daily_tracker.xlsx` 파일은 다음과 같은 열로 구성됩니다:
+
+| 열 이름 | 설명 |
+|---------|------|
+| 날짜 | 거래 날짜 (YYYY-MM-DD) |
+| 전일종가 | 전 거래일 종가 |
+| 시가 | 당일 시가 |
+| 종가 | 당일 종가 |
+| 최고가 | 당일 최고가 |
+| 최저가 | 당일 최저가 |
+| 거래량 | 거래량 |
+| 변동가격 | 전일 대비 변동 금액 |
+| 변동률(%) | 전일 대비 변동률 |
+| 뉴스/이유 | 당일 관련 뉴스 요약 |
+
+## 출력 예시
+
+```
+============================================================
+NVIDIA 일일 주가 추적기
+============================================================
+
+오늘 날짜로 추적합니다: 2026-01-15
+
+📊 NVIDIA(NVDA) 주가 데이터를 가져오는 중...
+
+날짜: 2026-01-15
+전일 종가: $145.23
+시가: $146.00
+종가: $148.75
+최고가: $149.50
+최저가: $145.80
+거래량: 45,678,900
+변동: $3.52 (2.42%)
+
+📰 뉴스를 가져오는 중...
+
+총 3개의 뉴스를 찾았습니다:
+1. [Reuters] NVIDIA announces new AI chip breakthrough
+   발행: 2026-01-15 09:30:00
+   링크: https://...
+
+💾 Excel 파일에 기록을 저장하는 중...
+
+✅ 성공적으로 기록되었습니다!
+파일 위치: nvda_daily_tracker.xlsx
+
+============================================================
+추적 완료!
+============================================================
+```
+
+## 함수 설명
+
+### finance_util.py
+
+#### `fetch_daily_stock_data(symbol, date=None)`
+- Yahoo Finance API를 사용하여 주가 데이터 가져오기
+- symbol: 주식 티커 (예: 'NVDA')
+- date: 조회할 날짜 (None이면 오늘)
+
+#### `fetch_stock_news(symbol, date=None, max_results=5)`
+- Google News RSS를 사용하여 뉴스 가져오기
+- symbol: 주식 티커
+- date: 조회할 날짜
+- max_results: 최대 뉴스 개수
+
+#### `append_daily_record(stock_data, news_summary, filename, output_dir=None)`
+- Excel 파일에 일일 기록 추가
+- 파일이 없으면 새로 생성
+- 같은 날짜가 이미 있으면 업데이트
+
+## 활용 방법
+
+### 1. 매일 자동 실행 (크론잡)
+
+```bash
+# 매일 오후 5시에 실행
+0 17 * * * cd /path/to/repo && python nvda_daily_tracker.py
+```
+
+### 2. 과거 데이터 수집
+
+```bash
+# 최근 일주일 데이터 수집 (예시)
+for date in 2026-01-09 2026-01-10 2026-01-13 2026-01-14 2026-01-15; do
+    python nvda_daily_tracker.py $date
+    sleep 2
+done
+```
+
+### 3. 프로그래밍 방식 사용
+
+```python
+from finance_util import fetch_daily_stock_data, fetch_stock_news, append_daily_record
+
+# 주가 데이터 가져오기
+stock_data = fetch_daily_stock_data('NVDA', '2026-01-15')
+print(f"종가: ${stock_data['close']}, 변동률: {stock_data['change_pct']}%")
+
+# 뉴스 가져오기
+news = fetch_stock_news('NVDA', '2026-01-15')
+for item in news:
+    print(f"{item['title']} - {item['publisher']}")
+
+# Excel에 저장
+news_summary = " | ".join([f"{n['title']}" for n in news[:3]])
+append_daily_record(stock_data, news_summary)
+```
+
+## 장기 분석 활용
+
+이 도구로 수집한 데이터를 사용하여:
+
+1. **주가 변동 패턴 분석**: 날짜별 변동률과 뉴스의 상관관계 파악
+2. **뉴스 영향도 분석**: 특정 뉴스 키워드와 주가 변동의 관계 분석
+3. **장기 트렌드 파악**: 누적된 데이터로 장기 추세 분석
+4. **이벤트 영향 측정**: 특정 이벤트(실적 발표, 신제품 출시 등)의 영향도 측정
+
+## 데이터 소스
+
+- **주가 데이터**: Yahoo Finance API
+- **뉴스 데이터**: Google News RSS Feed
+
+## 주의사항
+
+1. **거래일 한정**: 주말과 공휴일은 가장 최근 거래일의 데이터가 반환됩니다
+2. **네트워크 필수**: 인터넷 연결이 필요합니다
+3. **API 제한**: 과도한 요청은 차단될 수 있으니 적절한 간격을 두고 실행하세요
+4. **뉴스 정확도**: 뉴스는 자동 수집되므로 관련성을 직접 확인해야 합니다
+
+## 문제 해결
+
+### 주가 데이터를 가져올 수 없을 때
+- 인터넷 연결 확인
+- Yahoo Finance API 접근 가능 여부 확인
+- 프록시 설정 확인
+
+### 뉴스를 가져올 수 없을 때
+- Google News RSS 접근 가능 여부 확인
+- 뉴스가 없을 경우 "뉴스 없음"으로 기록됨
+
+### Excel 파일 오류
+- 파일이 다른 프로그램에서 열려있지 않은지 확인
+- 출력 디렉토리에 쓰기 권한이 있는지 확인
+
+## 라이선스
+
+MIT License
+
+## 기여
+
+개선 사항이나 버그 리포트는 이슈로 등록해주세요.

--- a/nvda_daily_tracker.py
+++ b/nvda_daily_tracker.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+NVIDIA Daily Stock Tracker
+
+이 스크립트는 NVIDIA(NVDA)의 일일 주가 변동과 이유를 추적합니다.
+매일 실행하여 주가 데이터와 뉴스를 수집하고 Excel 파일에 저장합니다.
+"""
+
+import sys
+from datetime import datetime
+from finance_util import fetch_daily_stock_data, fetch_stock_news, append_daily_record
+
+
+def format_news_summary(news_items):
+    """
+    뉴스 항목들을 요약 문자열로 변환합니다.
+
+    Args:
+        news_items (list): 뉴스 항목 리스트
+
+    Returns:
+        str: 뉴스 요약 문자열
+    """
+    if not news_items:
+        return "뉴스 없음"
+
+    summary_parts = []
+    for i, news in enumerate(news_items[:3], 1):  # 최대 3개 뉴스
+        title = news['title']
+        publisher = news['publisher']
+        summary_parts.append(f"{i}. [{publisher}] {title}")
+
+    return " | ".join(summary_parts)
+
+
+def track_nvda_daily(date=None, output_dir=None):
+    """
+    NVIDIA의 일일 주가를 추적하고 기록합니다.
+
+    Args:
+        date (str): 추적할 날짜 (YYYY-MM-DD 형식, None이면 오늘)
+        output_dir (str): 출력 디렉토리 경로 (None이면 현재 디렉토리)
+
+    Returns:
+        dict: 추적 결과 정보
+    """
+    symbol = 'NVDA'
+
+    try:
+        # 1. 주가 데이터 가져오기
+        print(f"📊 NVIDIA(NVDA) 주가 데이터를 가져오는 중...")
+        stock_data = fetch_daily_stock_data(symbol, date)
+
+        print(f"\n날짜: {stock_data['date']}")
+        print(f"전일 종가: ${stock_data['prev_close']}")
+        print(f"시가: ${stock_data['open']}")
+        print(f"종가: ${stock_data['close']}")
+        print(f"최고가: ${stock_data['high']}")
+        print(f"최저가: ${stock_data['low']}")
+        print(f"거래량: {stock_data['volume']:,}")
+        print(f"변동: ${stock_data['change']} ({stock_data['change_pct']}%)")
+
+        # 2. 뉴스 가져오기
+        print(f"\n📰 뉴스를 가져오는 중...")
+        news_items = fetch_stock_news(symbol, stock_data['date'])
+
+        if news_items:
+            print(f"\n총 {len(news_items)}개의 뉴스를 찾았습니다:")
+            for i, news in enumerate(news_items, 1):
+                print(f"{i}. [{news['publisher']}] {news['title']}")
+                print(f"   발행: {news['published']}")
+                print(f"   링크: {news['link']}")
+        else:
+            print("관련 뉴스를 찾지 못했습니다.")
+
+        # 3. 뉴스 요약
+        news_summary = format_news_summary(news_items)
+
+        # 4. Excel에 기록 추가
+        print(f"\n💾 Excel 파일에 기록을 저장하는 중...")
+        filepath = append_daily_record(stock_data, news_summary, output_dir=output_dir)
+
+        print(f"\n✅ 성공적으로 기록되었습니다!")
+        print(f"파일 위치: {filepath}")
+
+        return {
+            'success': True,
+            'date': stock_data['date'],
+            'close': stock_data['close'],
+            'change_pct': stock_data['change_pct'],
+            'news_count': len(news_items),
+            'filepath': filepath
+        }
+
+    except Exception as e:
+        print(f"\n❌ 오류 발생: {str(e)}", file=sys.stderr)
+        return {
+            'success': False,
+            'error': str(e)
+        }
+
+
+def main():
+    """메인 실행 함수"""
+    print("=" * 60)
+    print("NVIDIA 일일 주가 추적기")
+    print("=" * 60)
+
+    # 명령행 인자 처리
+    date = None
+    output_dir = None
+
+    if len(sys.argv) > 1:
+        date = sys.argv[1]
+        print(f"\n지정된 날짜: {date}")
+    else:
+        print(f"\n오늘 날짜로 추적합니다: {datetime.now().strftime('%Y-%m-%d')}")
+
+    if len(sys.argv) > 2:
+        output_dir = sys.argv[2]
+        print(f"출력 디렉토리: {output_dir}")
+
+    print()
+
+    # 추적 실행
+    result = track_nvda_daily(date, output_dir)
+
+    if result['success']:
+        print("\n" + "=" * 60)
+        print("추적 완료!")
+        print("=" * 60)
+        return 0
+    else:
+        print("\n" + "=" * 60)
+        print("추적 실패")
+        print("=" * 60)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas>=2.0.0
+openpyxl>=3.1.0
+requests>=2.31.0


### PR DESCRIPTION
일일 주가 변동과 이유를 추적하는 NVIDIA 주식 추적 시스템을 구현했습니다.

주요 기능:
- 일일 주가 데이터 수집 (시가, 종가, 최고가, 최저가, 거래량)
- 전일 대비 변동가격 및 변동률 자동 계산
- 당일 관련 뉴스 자동 수집 (Google News RSS)
- Excel 파일에 자동 누적 저장
- 중복 날짜 자동 업데이트

새로운 파일:
- nvda_daily_tracker.py: 메인 실행 스크립트
- README.md: 사용 설명서

수정된 파일:
- finance_util.py:
  * fetch_daily_stock_data(): Yahoo Finance API로 주가 데이터 가져오기
  * fetch_stock_news(): Google News로 뉴스 수집
  * append_daily_record(): Excel에 일일 기록 추가
- requirements.txt: requests 추가

기술 구현:
- Yahoo Finance V8 API를 사용한 실시간 주가 조회
- Google News RSS를 사용한 뉴스 수집
- pandas와 openpyxl을 사용한 Excel 파일 관리
- 날짜별 정렬 및 중복 방지 로직

사용 방법:
python nvda_daily_tracker.py [날짜] [출력디렉토리]

장기 누적하여 주가 변동과 뉴스의 상관관계를 분석할 수 있습니다.